### PR TITLE
Fix homepage

### DIFF
--- a/fluent-plugin-clickhouse.gemspec
+++ b/fluent-plugin-clickhouse.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Fluentd output plugin for inserting into ClickHouse.}
   spec.description   = %q{Fluentd output inserted into ClickHouse as fast column-oriented OLAP DBMS.}
-  spec.homepage      = "https://github.com/kumagi/fluentd-plugin-clickhouse."
+  spec.homepage      = "https://github.com/kumagi/fluent-plugin-clickhouse"
   spec.license       = "Apache2.0"
 
   spec.rubyforge_project = "fluent-plugin-clickhouse"


### PR DESCRIPTION
Users cannot find homepage from
https://rubygems.org/gems/fluent-plugin-clickhouse/versions/0.0.1
when the homepage link is broken.